### PR TITLE
Use symbols as well as colors to denote results

### DIFF
--- a/cloudweatherreport/static/css/base.css
+++ b/cloudweatherreport/static/css/base.css
@@ -29,7 +29,6 @@
 
 .test-result, .test-result:before, .test-result:after {
     padding: 0;
-    border-radius: 12px;
     height: 12px;
     min-width: 12px;
     display: inline-block;
@@ -37,16 +36,13 @@
 
 .pass, .pass:before, .pass:after {
     color: #18A900;
-    background-color: #18A900;
 }
 
 .fail, .fail:before, .fail:after{
     color: #ff3300;
-    background-color: #ff3300;
 }
 .no-result, .no-result:before, .no-result:after {
     color:#ccc;
-    background-color:#ccc;
 }
 
 .history{

--- a/cloudweatherreport/static/css/base2.css
+++ b/cloudweatherreport/static/css/base2.css
@@ -27,7 +27,6 @@
 }
 .test-result, .test-result:before, .test-result:after {
     padding: 0;
-    border-radius: 12px;
     height: 12px;
     min-width: 12px;
     display: inline-block;
@@ -35,16 +34,13 @@
 
 .pass, .pass:before, .pass:after {
     color: #18A900;
-    background-color: #18A900;
 }
 
 .fail, .fail:before, .fail:after{
     color: #ff3300;
-    background-color: #ff3300;
 }
 .no-result, .no-result:before, .no-result:after {
     color:#ccc;
-    background-color:#ccc;
 }
 
 .last-result {

--- a/cloudweatherreport/templates/base.html
+++ b/cloudweatherreport/templates/base.html
@@ -21,13 +21,13 @@
 </head>
 {% macro display_status_img(value, size='30px') -%}
     {% if value == 'PASS' or value == 'All Passed' %}
-        <span class="test-result pass"></span>
+        <span class="test-result pass">&#x2714;</span>
     {% elif value == 'FAIL' or value == 'All Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% elif value == 'Some Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% else %}
-        <span class="test-result no-result"></span>
+        <span class="test-result no-result">&#x26AB;</span>
     {% endif %}
 {%- endmacro %}
 <body class="details-page">

--- a/cloudweatherreport/templates/base_2.html
+++ b/cloudweatherreport/templates/base_2.html
@@ -71,13 +71,13 @@
 </head>
 {% macro display_status_img(value, size='30px') -%}
     {% if value == 'PASS' or value == 'All Passed' %}
-        <span class="test-result pass"></span>
+        <span class="test-result pass">&#x2714;</span>
     {% elif value == 'FAIL' or value == 'All Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% elif value == 'Some Failed' %}
-        <span class="test-result fail"></span>
+        <span class="test-result fail">&#x2718;</span>
     {% else %}
-        <span class="test-result no-result"></span>
+        <span class="test-result no-result">&#x26AB;</span>
     {% endif %}
 {%- endmacro %}
 <body class="details-page">

--- a/cloudweatherreport/tests/test_reporter.py
+++ b/cloudweatherreport/tests/test_reporter.py
@@ -257,6 +257,17 @@ class TestReporter(TestCase):
                         "DefaultSeries": "trusty",
                         "Name": "joyent"
                     }
+                },
+                {
+                    "provider_name": "GCE",
+                    "test_outcome": "No Results",
+                    "info": {
+                        "ServerUUID": "0caecc18-b694-4e4c-81e7-a0551bcb7258",
+                        "ProviderType": "gce",
+                        "UUID": "0caecc18-b694-4e4c-81e7-a0551bcb7258",
+                        "DefaultSeries": "trusty",
+                        "Name": "gce"
+                    }
                 }
             ],
             "bundle": {


### PR DESCRIPTION
This fixes #38 by providing non-color cues for the result to enable color-blind users to distinguish them.

![issue-38](https://cloud.githubusercontent.com/assets/406082/15583247/10f73286-2343-11e6-94ce-fb582ca63b57.png)