### PR TITLE
Support multiple bundles in a single test plan.

### DIFF
--- a/cloudweatherreport/cloud_weather_report.py
+++ b/cloudweatherreport/cloud_weather_report.py
@@ -23,7 +23,6 @@ from utils import (
     find_unit,
     get_provider_name,
     mkdir_p,
-    read_file,
     run_action,
 )
 
@@ -166,17 +165,16 @@ def generate_report(bundle, results, options, status, html_filename,
                       json_filename=json_filename)
 
 
-def main(args):
+def main(args, test_plan):
     log_level = logging.DEBUG if args.verbose else logging.INFO
     configure_logging(log_level)
     logging.info('Cloud Weather Report started.')
-    test_plan = None
-    if args.test_plan:
-        test_plan = read_file(args.test_plan, 'yaml')
     results = []
     bundle = test_plan.get('bundle')
+    args.bundle = test_plan.get('bundle_file')
     html_filename, json_filename = get_filenames(bundle)
     last_successful_status = None
+
     for env_name in args.controller:
         env = jujuclient.Environment.connect(env_name=env_name)
         env_info = env.info()
@@ -196,6 +194,7 @@ def main(args):
             "test_results": json.loads(test_results) if test_results else None,
             "action_results": benchmark_results,
             "info": env_info})
+
     generate_report(
         bundle=bundle, results=results, options=args,
         status=last_successful_status, html_filename=html_filename,

--- a/cloudweatherreport/examples/multi-test-plans.yaml
+++ b/cloudweatherreport/examples/multi-test-plans.yaml
@@ -1,0 +1,9 @@
+-   bundle: bundle:apache-analytics-pig
+    benchmark:
+        resourcemanager:
+            terasort
+    bundle_name: apache-analytics-pig
+    bundle_file: bundle.yaml
+
+-   bundle: cs:git
+    bundle_name: git

--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import subprocess
 import sys
 
@@ -5,6 +7,7 @@ from cloud_weather_report import (
     main,
     parse_args
 )
+from utils import read_file
 
 
 def file_open_with_app(filename):
@@ -18,9 +21,12 @@ def file_open_with_app(filename):
 
 def entry():
     args = parse_args()
-    html_filename = main(args)
-    print("Test result:\n  {}".format(html_filename))
-    file_open_with_app((html_filename))
+    test_plans = read_file(args.test_plan, 'yaml')
+    test_plans = [test_plans] if isinstance(test_plans, dict) else test_plans
+    for test_plan in test_plans:
+        html_filename = main(args, test_plan)
+        print("Test result:\n  {}".format(html_filename))
+        file_open_with_app((html_filename))
 
 
 if __name__ == '__main__':

--- a/cloudweatherreport/tests/test_run.py
+++ b/cloudweatherreport/tests/test_run.py
@@ -1,0 +1,57 @@
+from argparse import Namespace
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+from mock import (
+    call,
+    patch,
+)
+
+from run import entry
+from tests.test_cloud_weather_report import (
+    make_tst_plan,
+    make_tst_plan_file,
+)
+
+
+class TestRun(TestCase):
+
+    def test_entry(self):
+        with NamedTemporaryFile() as test_plan:
+            make_tst_plan_file(test_plan.name)
+            with patch('run.main', return_value='/tmp/html') as mock_main:
+                args = self.make_args(test_plan.name)
+                with patch('run.parse_args', autospec=True,
+                           return_value=args) as mock_pa:
+                    with patch('run.file_open_with_app') as mock_fowp:
+                        with patch('__builtin__.print') as mock_print:
+                            entry()
+        mock_main.assert_called_once_with(args, make_tst_plan())
+        mock_pa.assert_called_once_with()
+        mock_fowp.assert_called_once_with('/tmp/html')
+        mock_print.assert_called_once_with('Test result:\n  /tmp/html')
+
+    def test_entry_multi_test_plans(self):
+        with NamedTemporaryFile() as test_plan:
+            make_tst_plan_file(test_plan.name, multi_test_plans=True)
+            with patch('run.main', return_value='/tmp/html') as mock_main:
+                args = self.make_args(test_plan.name)
+                with patch('run.parse_args', autospec=True,
+                           return_value=args) as mock_pa:
+                    with patch('run.file_open_with_app') as mock_fowp:
+                        with patch('__builtin__.print'):
+                            entry()
+        mock_pa.assert_called_once_with()
+        self.assertEqual(mock_fowp.mock_calls,
+                         [call('/tmp/html'), call('/tmp/html')])
+        test_plans = make_tst_plan(multi_test_plans=True)
+        calls = [
+            call(args, (test_plans[0])),
+            call(args, (test_plans[1])),
+        ]
+        self.assertEqual(mock_main.mock_calls, calls)
+
+    def make_args(self, test_plan):
+        return Namespace(
+            controller=['aws'], result_output=None,
+            test_plan=test_plan, testdir='git', verbose=False)


### PR DESCRIPTION
This PR adds support for defining multiple bundles in a single test plan file. Added example in  examples/multi-test-plans.yaml file. 
