### PR TITLE
Make S3 files public by default

### DIFF
--- a/cloudweatherreport/datastore.py
+++ b/cloudweatherreport/datastore.py
@@ -17,7 +17,7 @@ class DataStore(object):
     """
 
     @classmethod
-    def get(cls, prefix, s3_bucket=None, s3_creds_file=None):
+    def get(cls, prefix, s3_bucket=None, s3_creds_file=None, public=True):
         """
         Get a LocalDataStore or S3DataStore instance depending on whether
         S3 is provided.
@@ -25,7 +25,8 @@ class DataStore(object):
         if s3_bucket:
             return S3DataStore(prefix,
                                s3_bucket,
-                               s3_creds_file)
+                               s3_creds_file,
+                               public)
         else:
             return LocalDataStore(prefix)
 
@@ -166,7 +167,7 @@ class S3DataStore(DataStore):
     Data store implementation using Amazon's S3.
     """
 
-    def __init__(self, prefix, bucket_name, creds_file):
+    def __init__(self, prefix, bucket_name, creds_file, public):
         super(S3DataStore, self).__init__(prefix)
         config = ConfigParser()
         with open(creds_file) as fp:
@@ -175,6 +176,7 @@ class S3DataStore(DataStore):
         self.secret_key = config.get('default', 'secret_key')
         self.bucket_name = bucket_name
         self._bucket = None
+        self.public = public
 
     @property
     def bucket(self):
@@ -226,6 +228,8 @@ class S3DataStore(DataStore):
             'Content-Type': content_type or 'text/plain',
             'Content-Encoding': encoding,
         })
+        if self.public:
+            key.set_canned_acl('public-read')
 
     def delete(self, filename):
         """

--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -39,6 +39,9 @@ def parse_args(argv=None):
                              'instead of locally')
     parser.add_argument('--s3-creds',
                         help='Path to config file containing S3 credentials')
+    parser.add_argument('--s3-private', dest='s3_public',
+                        action='store_false', default=True,
+                        help='Do not make the files written to S3 public-read')
     parser.add_argument('--results-per-bundle', default=40, type=int,
                         help='Maximum number of results to list per bundle in '
                              'the index.  Older results will not be listed, '
@@ -152,7 +155,8 @@ class Runner(mp.Process):
         datastore = DataStore.get(
             self.args.results_dir,
             self.args.bucket,
-            self.args.s3_creds)
+            self.args.s3_creds,
+            self.args.s3_public)
         svg_data = fetch_svg(test_result.bundle_yaml)
         with datastore.lock():
             index = self.load_index(datastore)


### PR DESCRIPTION
Files written to S3 were created with default (non-public) ACL.  This makes them public by default, with an option to suppress that behavior.