### PR TITLE
Cleanup temporary files.

### DIFF
--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -25,6 +25,7 @@ from cloudweatherreport.utils import (
     get_juju_major_version,
     get_versioned_juju_api,
     generate_test_id,
+    temp_env,
 )
 
 
@@ -252,11 +253,12 @@ class Runner(mp.Process):
 def entry_point():
     args = parse_args()
     processes = []
-    for controller in args.controllers:
-        processes.append(Runner(controller, args))
-        processes[-1].start()
-    for p in processes:
-        p.join()
+    with temp_env():
+        for controller in args.controllers:
+            processes.append(Runner(controller, args))
+            processes[-1].start()
+        for p in processes:
+            p.join()
 
 
 if __name__ == '__main__':

--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -25,7 +25,7 @@ from cloudweatherreport.utils import (
     get_juju_major_version,
     get_versioned_juju_api,
     generate_test_id,
-    temp_env,
+    temp_tmpdir,
 )
 
 
@@ -253,7 +253,7 @@ class Runner(mp.Process):
 def entry_point():
     args = parse_args()
     processes = []
-    with temp_env():
+    with temp_tmpdir():
         for controller in args.controllers:
             processes.append(Runner(controller, args))
             processes[-1].start()

--- a/cloudweatherreport/utils.py
+++ b/cloudweatherreport/utils.py
@@ -12,6 +12,7 @@ import os
 from shutil import rmtree
 import socket
 import subprocess
+import tempfile
 from tempfile import mkdtemp
 from time import sleep
 import traceback
@@ -205,14 +206,16 @@ def temp_dir(parent=None, keep=False, prefix='cwr-tmp-'):
 
 
 @contextmanager
-def temp_env():
+def temp_tmpdir():
     with temp_dir() as tmp:
-        old_tmpdir = os.environ.get('TMPDIR', '')
+        tempdir = tempfile.tempdir
         try:
-            os.environ['TMPDIR'] = tmp
+            # Setting TMPDIR env doesn't seem to be honoured by Python once
+            # the tempdir is already set.
+            tempfile.tempdir = tmp
             yield
         finally:
-            os.environ['TMPDIR'] = old_tmpdir
+            tempfile.tempdir = tempdir
 
 
 @contextmanager

--- a/cloudweatherreport/utils.py
+++ b/cloudweatherreport/utils.py
@@ -195,13 +195,24 @@ def find_unit(unit, status):
 
 
 @contextmanager
-def temp_dir(parent=None, keep=False):
-    directory = mkdtemp(dir=parent)
+def temp_dir(parent=None, keep=False, prefix='cwr-tmp-'):
+    directory = mkdtemp(dir=parent, prefix=prefix)
     try:
         yield directory
     finally:
         if not keep:
             rmtree(directory)
+
+
+@contextmanager
+def temp_env():
+    with temp_dir() as tmp:
+        old_tmpdir = os.environ.get('TMPDIR', '')
+        try:
+            os.environ['TMPDIR'] = tmp
+            yield
+        finally:
+            os.environ['TMPDIR'] = old_tmpdir
 
 
 @contextmanager


### PR DESCRIPTION
Resolves #79 

Setting `os.environ['TMPDIR']` doesn't seem to be honored by Python once `tempfile.tempdir` is initially set. 

Tested by watching `/tmp` directory.  When `cwr` starts to run, it creates a temporary directory prefixed with `cwr-tmp-` in `/tmp` directory. All other temporary directories and files seems to be created within `/tmp/cwr-tmp-*/*` and get deleted once `cwr` completes execution. 