### PR TITLE
Detect Amulet INFRA_FAIL results even if caught by unittest

### DIFF
--- a/cloudweatherreport/model.py
+++ b/cloudweatherreport/model.py
@@ -541,7 +541,7 @@ class SuiteResult(BaseModel):
             is_exception = 'Traceback' in output
             lint_exception = lint_or_proof and is_exception
             no_result = None in (test_name, returncode)
-            amulet_infra = returncode == 200
+            amulet_infra = returncode == 200 or 'SystemExit: 200' in output
             deploy_fail = test_name == 'juju-deployer'
             hook_fail = 'hook failed' in output
             timeout = 'TimeoutError' in output

--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -254,11 +254,14 @@ def entry_point():
     args = parse_args()
     processes = []
     with temp_tmpdir():
-        for controller in args.controllers:
-            processes.append(Runner(controller, args))
-            processes[-1].start()
-        for p in processes:
-            p.join()
+        if len(args.controllers) > 1:
+            for controller in args.controllers:
+                processes.append(Runner(controller, args))
+                processes[-1].start()
+            for p in processes:
+                p.join()
+        else:
+            Runner(args.controllers[0], args).run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The unittest library surfaces Amulet's INFRA_FAIL if it occurs during `setUp` or `setUpClass`, but catches and masks it when it occurs during a test case method.

Also, avoid a subprocess when only running a single controller.