### PR TITLE
Use bundle_name field from test plan

### DIFF
--- a/cloudweatherreport/model.py
+++ b/cloudweatherreport/model.py
@@ -332,6 +332,16 @@ class TestPlan(BaseModel):
     def report_filename(self, test_id):
         return Report(
             test_id=test_id,
+            bundle=BundleInfo(name=self.bundle_name, url=self.url),
+        ).filename_json
+
+    def old_report_filename(self, test_id):
+        """
+        Deprecated file name based on the `bundle` field instead of
+        the `bundle_name` field.
+        """
+        return Report(
+            test_id=test_id,
             bundle=BundleInfo(name=self.bundle, url=self.url),
         ).filename_json
 
@@ -339,6 +349,7 @@ class TestPlan(BaseModel):
 class BundleInfo(BaseModel):
     fields = {
         'machines': None,
+        'ref': basestring,
         'name': basestring,
         'relations': None,
         'services': None,
@@ -777,7 +788,8 @@ class ReportIndex(BaseModel):
         which was created just prior to the given report.
         """
         for index_item in self.reports:
-            if index_item.bundle_name != report.bundle.name:
+            if index_item.bundle_name not in (report.bundle.name,
+                                              report.bundle.ref):
                 continue
             if index_item.date < report.date:
                 return index_item

--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -105,15 +105,20 @@ class Runner(mp.Process):
 
     def load_report(self, datastore, index, test_plan):
         filename = test_plan.report_filename(self.test_id)
+        old_filename = test_plan.old_report_filename(self.test_id)
         if datastore.exists(filename):
             report = model.Report.from_json(datastore.read(filename))
+        elif datastore.exists(old_filename):
+            report = model.Report.from_json(datastore.read(old_filename))
         else:
             report = model.Report(
                 version=2,
                 test_id=self.test_id,
                 date=datetime.now(),
                 bundle=model.BundleInfo(
-                    name=test_plan.bundle, url=test_plan.url),
+                    ref=test_plan.bundle,
+                    name=test_plan.bundle_name,
+                    url=test_plan.url),
             )
             prev_report = index.find_previous_report(report)
             if prev_report:


### PR DESCRIPTION
The name of the bundle is given in the test plan, but isn't used for
display and filename purposes.  This attempts to correct that in a
backwards compatible way.