### PR TITLE
Add option to regenerate index

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -273,6 +273,7 @@ class TestRunner(unittest.TestCase):
             log_level='INFO',
             no_destroy=False,
             remove_test=None,
+            regenerate_index=None,
             results_dir='results',
             results_per_bundle=40,
             s3_creds=None,


### PR DESCRIPTION
This is mainly useful to create a fresh (empty) index before any tests are run.