### PR TITLE
Delete old datastore locks.

### DIFF
--- a/cloudweatherreport/datastore.py
+++ b/cloudweatherreport/datastore.py
@@ -1,10 +1,16 @@
-import os
-from time import sleep
 from contextlib import contextmanager
 from ConfigParser import ConfigParser
+import datetime
+import logging
+import os
 from mimetypes import MimeTypes
+from time import sleep, time
 from uuid import uuid4
+
 from boto.s3.connection import S3Connection
+
+
+log = logging.getLogger(__name__)
 
 
 class TimeoutError(Exception):
@@ -69,7 +75,7 @@ class DataStore(object):
         raise NotImplementedError()
 
     @contextmanager
-    def lock(self, timeout=5*60):
+    def lock(self, timeout=5*60, old_lock_age=60*60):
         """
         Context manager that acquires a lock for the datastore.
 
@@ -79,6 +85,10 @@ class DataStore(object):
         This depends on the underlying store supporting read-after-write
         consistency for new files, and eventual consistency for deleted
         files.
+
+        :param timeout:  Timeout in seconds to acquire a lock.
+        :param old_lock_age: Old lock age in seconds. If set to a number,
+          it deletes all other locks older than old_lock_age.
         """
         # S3 ensures read-after-write consistency for new objects, and eventual
         # consistency for updates or deletes.  This implements an optimistic
@@ -87,24 +97,59 @@ class DataStore(object):
         # Optimistically create our unique lock file.  This relies on RAW
         # consistency to ensure it will be immediately visible to others,
         # and their lock files to us.
-        lock_id = uuid4()
+        lock_id = self.create_lock_id()
         lock_filename = '.lock.{}'.format(lock_id)
         self.write(lock_filename, '')
+        log.debug("Trying to acquire datastore lock {}".format(lock_filename))
         try:
             # wait until we own the earliest lock file, and thus the lock
             wait_secs = 1
             total_waited = 0
-            while self._active_lock_filename() != lock_filename:
+            active_lock = self._active_lock_filename()
+            while active_lock != lock_filename:
+                log.debug('Lock already acquired {} age:{} sec.'.format(
+                    active_lock, int(self.age_in_seconds(active_lock))))
+                self.delete_old_lock(active_lock, old_lock_age)
                 sleep(wait_secs)
                 total_waited += wait_secs
                 if total_waited >= timeout:
-                    raise TimeoutError('Timed out waiting for lock')
+                    raise TimeoutError(
+                        'Timed out waiting for lock:{}'.format(lock_filename))
                 # increase sleep time a second at a time, up to 10s
                 if wait_secs < 10:
                     wait_secs += 1
+                active_lock = self._active_lock_filename()
+            log.debug('Datastore lock acquired {}'.format(lock_filename))
             yield lock_id
         finally:
+            log.debug('Datastore lock released {}'.format(lock_filename))
             self.delete(lock_filename)
+
+    def create_lock_id(self):
+        """Create lock id.
+
+        If it is running in Jenkins, it will postfix the lock id with the job
+        name and build number.
+        """
+        job_name = os.getenv('JOB_NAME')
+        build_number = os.getenv('BUILD_NUMBER')
+        if job_name and build_number:
+            return '{}.{}.{}'.format(uuid4(), job_name, build_number)
+        return uuid4()
+
+    def delete_old_lock(self, lock, old_age):
+        """Delete a lock older than old_age."""
+        age = self.age_in_seconds(lock)
+        if old_age is not None and age > old_age:
+            log.info('Deleting old datastore lock:{} age:{} sec'.format(
+                lock, int(age)))
+            self.delete(lock)
+
+    def age_in_seconds(self, filename):
+        """
+        File age in seconds.
+        """
+        raise NotImplementedError()
 
     def _active_lock_filename(self):
         for filename in self.list():
@@ -161,13 +206,17 @@ class LocalDataStore(DataStore):
         filename = self._path(filename)
         os.remove(filename)
 
+    def age_in_seconds(self, filename):
+        return time() - os.path.getmtime(self._path(filename))
+
 
 class S3DataStore(DataStore):
     """
     Data store implementation using Amazon's S3.
     """
 
-    def __init__(self, prefix, bucket_name, creds_file, public):
+    def __init__(self, prefix, bucket_name, creds_file, public,
+                 debug_level=logging.INFO):
         super(S3DataStore, self).__init__(prefix)
         config = ConfigParser()
         with open(creds_file) as fp:
@@ -177,6 +226,7 @@ class S3DataStore(DataStore):
         self.bucket_name = bucket_name
         self._bucket = None
         self.public = public
+        self.set_logging(debug_level)
 
     @property
     def bucket(self):
@@ -187,6 +237,12 @@ class S3DataStore(DataStore):
             else:
                 self._bucket = conn.create_bucket(self.bucket_name)
         return self._bucket
+
+    @staticmethod
+    def set_logging(level):
+        logger = logging.getLogger('boto')
+        logger.propagate = False
+        logger.setLevel(level)
 
     def list(self, path=None):
         """
@@ -237,3 +293,12 @@ class S3DataStore(DataStore):
         """
         if self.exists(filename):
             self.bucket.delete_key(self._path(filename))
+
+    def age_in_seconds(self, filename):
+        key = self.bucket.get_key(self._path(filename))
+        # Date format return from boto: Tue, 28 Mar 2017 13:30:37 GMT
+        # The last_modified attirbute has different date format for the
+        # bucket.list() and bucket.get_key() functions.
+        modified = datetime.datetime.strptime(
+            key.last_modified, '%a, %d %b %Y %H:%M:%S %Z')
+        return (datetime.datetime.utcnow() - modified).total_seconds()

--- a/cloudweatherreport/datastore.py
+++ b/cloudweatherreport/datastore.py
@@ -109,7 +109,7 @@ class DataStore(object):
             while active_lock != lock_filename:
                 log.debug('Lock already acquired {} age:{} sec.'.format(
                     active_lock, int(self.age_in_seconds(active_lock))))
-                self.delete_old_lock(active_lock, old_lock_age)
+                self.delete_lock_if_old(active_lock, old_lock_age)
                 sleep(wait_secs)
                 total_waited += wait_secs
                 if total_waited >= timeout:
@@ -137,7 +137,7 @@ class DataStore(object):
             return '{}.{}.{}'.format(uuid4(), job_name, build_number)
         return uuid4()
 
-    def delete_old_lock(self, lock, old_age):
+    def delete_lock_if_old(self, lock, old_age):
         """Delete a lock older than old_age."""
         age = self.age_in_seconds(lock)
         if old_age is not None and age > old_age:

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import shutil
 from unittest import TestCase
@@ -23,9 +24,12 @@ class TestDataStore(TestCase):
     @mock.patch.object(datastore.DataStore, 'delete')
     @mock.patch.object(datastore.DataStore, '_active_lock_filename')
     @mock.patch.object(datastore.DataStore, 'write')
-    def test_lock(self, ds_write, ds_alf, ds_delete, ds_sleep, ds_uuid4):
+    @mock.patch.object(datastore.DataStore, 'age_in_seconds')
+    def test_lock(self, ds_age, ds_write, ds_alf, ds_delete, ds_sleep,
+                  ds_uuid4):
         ds = datastore.DataStore('prefix')
         ds_uuid4.return_value = 'uuid'
+        ds_age.return_value = 1
 
         # test no contest
         ds_alf.return_value = '.lock.uuid'
@@ -69,6 +73,26 @@ class TestDataStore(TestCase):
         ])
         ds_delete.assert_called_once_with('.lock.uuid')
 
+    @mock.patch.object(datastore, 'uuid4')
+    @mock.patch.object(datastore, 'sleep')
+    @mock.patch.object(datastore.DataStore, 'delete')
+    @mock.patch.object(datastore.DataStore, '_active_lock_filename')
+    @mock.patch.object(datastore.DataStore, 'write')
+    @mock.patch.object(datastore.DataStore, 'age_in_seconds')
+    def test_lock_delete_old_lock(self, ds_age, ds_write, ds_alf, ds_delete,
+                                  ds_sleep, ds_uuid4):
+        ds = datastore.DataStore('prefix')
+        ds_uuid4.return_value = 'new'
+        ds_age.return_value = 10
+        ds_alf.side_effect = ['.lock.old', '.lock.new']
+        with ds.lock(old_lock_age=5) as lock_id:
+            pass
+        expected_calls = [mock.call('.lock.old'), mock.call('.lock.new')]
+        self.assertEqual(ds_delete.call_args_list, expected_calls)
+        self.assertEqual(lock_id, 'new')
+        ds_write.assert_called_once_with('.lock.new', '')
+        ds_sleep.assert_called_once_with(1)
+
     @mock.patch.object(datastore.DataStore, 'list')
     def test_active_lock_filename(self, ds_list):
         ds_list.return_value = [
@@ -84,6 +108,21 @@ class TestDataStore(TestCase):
             'qux',
         ]
         self.assertIsNone(ds._active_lock_filename())
+
+    @mock.patch('cloudweatherreport.datastore.uuid4')
+    def test_create_lock_id(self, uuid_mock):
+        uuid_mock.return_value = '1234'
+        job_name_org = os.getenv('JOB_NAME', '')
+        build_num_org = os.getenv('BUILD_NUMBER', '')
+        try:
+            os.environ['JOB_NAME'] = 'foo'
+            os.environ['BUILD_NUMBER'] = 'bar'
+            ds = datastore.DataStore('prefix')
+            lock_id = ds.create_lock_id()
+        finally:
+            os.environ['JOB_NAME'] = job_name_org
+            os.environ['BUILD_NUMBER'] = build_num_org
+        self.assertEqual(lock_id, '1234.foo.bar')
 
 
 class TestLocalDataStore(TestCase):
@@ -176,6 +215,24 @@ class TestLocalDataStore(TestCase):
                 with self.assertRaises(datastore.TimeoutError):
                     with self.ds.lock(timeout=1):
                         self.fail('Secondary lock should fail')
+
+    def test_age_in_seconds(self):
+        age = self.ds.age_in_seconds('file1')
+        self.assertGreater(age, 0)
+
+    def test_delete_old_lock(self):
+        self.ds.write('.lock.1', '')
+        self.assertIs(self.ds.exists('.lock.1'), True)
+        self.ds.delete_old_lock('.lock.1',  old_age=0)
+        self.assertIs(self.ds.exists('.lock.1'), False)
+
+    def test_delete_old_lock_ignore_old_locks(self):
+        lock = '.lock.1'
+        self.ds.write(lock, '')
+        self.assertIs(self.ds.exists(lock), True)
+        self.ds.delete_old_lock(lock, old_age=3600)
+        self.assertIs(self.ds.exists(lock), True)
+        self.ds.delete(lock)
 
 
 class TestS3DataStore(TestCase):
@@ -275,3 +332,38 @@ class TestS3DataStore(TestCase):
     def test_delete(self):
         self.ds.delete('test_del')
         self.ds.bucket.delete_key.assert_called_once_with('prefix/test_del')
+
+    def test_age_in_seconds(self):
+        self.ds.bucket.get_key.return_value = self.make_key()
+        # 30 min diff from last_modified date
+        date = datetime.datetime(2017, 3, 28, 13, 30, 0, 0)
+        # Can't patch datetime.datetime.utcnow, Maybe it is implemented in C
+        dt_mock = mock.Mock(wraps=datetime.datetime)
+        with mock.patch.object(datetime, 'datetime', dt_mock) as date_mock:
+            date_mock.utcnow.return_value = date
+            age = self.ds.age_in_seconds('test_del')
+        self.assertEqual(int(age), 1800)
+
+    def test_delete_old_lock(self):
+        self.ds.bucket.get_key.return_value = self.make_key()
+        lock = '.lock.1'
+        self.ds.write(lock, '')
+        with mock.patch.object(self.ds, 'delete', autospec=True) as del_mock:
+            self.ds.delete_old_lock(lock, old_age=0)
+        del_mock.assert_called_once_with(lock)
+
+    def test_delete_old_ignore_old_locks(self):
+        key = self.make_key()
+        self.ds.bucket.get_key.return_value = key
+        old_age = (datetime.datetime.utcnow() - datetime.datetime.strptime(
+            key.last_modified, '%a, %d %b %Y %H:%M:%S %Z')).total_seconds()
+        lock = '.lock.1'
+        self.ds.write(lock, '')
+        with mock.patch.object(self.ds, 'delete', autospec=True) as del_mock:
+            self.ds.delete_old_lock(lock, old_age=old_age+100)
+        self.assertIs(del_mock.called, False)
+
+    def make_key(self):
+        key = mock.Mock()
+        key.last_modified = 'Tue, 28 Mar 2017 13:00:00 GMT'
+        return key


### PR DESCRIPTION
- Delete any datastore locks that has been created for more than an hour.
- Make boto less noisy
- Post fix lock_id with Jenkins job name and build number (if running tests in Jenkins). In case of an issue, this info can be used the debug datastore timeout errors.  
- Add debug logging.

Bug #101 