### PR TITLE
Check for resource availability before performing tests.

### DIFF
--- a/cloudweatherreport/cloudresource/aws.py
+++ b/cloudweatherreport/cloudresource/aws.py
@@ -9,13 +9,19 @@ from cloudweatherreport.cloudresource import CloudResource
 __metaclass__ = type
 
 
+INSTANCE_LIMIT = 20
+SECURITY_GROUP_LIMIT = 500
+
+
 class AWS(CloudResource):
     """Determines if the requested resources are available for AWS cloud."""
 
-    def __init__(self, access_key, secret_key, region, instance_limit=20,
-                 security_group_limit=500):
+    def __init__(self, access_key, secret_key, region,
+                 instance_limit=INSTANCE_LIMIT,
+                 security_group_limit=SECURITY_GROUP_LIMIT):
         super(AWS, self).__init__(instance_limit, security_group_limit, None)
         self.client = make_client(access_key, secret_key, region)
+        self.region = region
 
     def is_instance_available(self, number_of_instances, _=None):
         """Return True if the number of requested instances are available.
@@ -27,8 +33,8 @@ class AWS(CloudResource):
         nodes = self.client.list_nodes()
         terminated = len([n for n in nodes if n.state == 'terminated'])
         instance_count = len(nodes) - terminated
-        logging.debug("AWS total instance:{} terminated:{} ".format(
-            nodes, terminated))
+        logging.debug("AWS total instance:{} terminated:{} region:{}".format(
+            len(nodes), terminated, self.region))
         return self.is_resource_available(
             number_of_instances, instance_count, self.instance_limit)
 
@@ -39,7 +45,7 @@ class AWS(CloudResource):
         :return: boolean
         """
         security_group_count = len(self.client.ex_list_security_groups())
-        logging.debug("AWS security groups.")
+        logging.debug("AWS security groups. Region:{}".format(self.region))
         return self.is_resource_available(
             request, security_group_count, self.security_group_limit)
 

--- a/cloudweatherreport/cloudresource/azure.py
+++ b/cloudweatherreport/cloudresource/azure.py
@@ -8,12 +8,17 @@ from cloudweatherreport.cloudresource import CloudResource
 
 __metaclass__ = type
 
+INSTANCE_LIMIT = 60
+SECURITY_GROUP_LIMIT = 100
+CORE_LIMIT = 20
+
 
 class Azure(CloudResource):
 
     def __init__(self, tenant_id, subscription_id, application_id,
-                 application_password, region, instance_limit=60,
-                 security_group_limit=100, core_limit=20):
+                 application_password, region, instance_limit=INSTANCE_LIMIT,
+                 security_group_limit=SECURITY_GROUP_LIMIT,
+                 core_limit=CORE_LIMIT):
         super(Azure, self).__init__(
             instance_limit, security_group_limit, core_limit)
         self.client = make_client(
@@ -30,12 +35,13 @@ class Azure(CloudResource):
         nodes = filter(lambda n: n.state != 'terminated', nodes)
 
         instance_count = len(nodes)
-        logging.info('Azure instance request')
+        logging.info('Azure instance request. Region:{}'.format(self.region))
         instance_available = self.is_resource_available(
             number_of_instances, instance_count, self.instance_limit)
 
         cpu_count = sum([self.get_cpu_size_from_node(n) for n in nodes])
-        logging.info('GCE CPU resource request')
+        logging.info(
+            'Azure CPU resource request. Region:{}'.format(self.region))
         cpu_available = self.is_resource_available(
             number_of_cpus, cpu_count, self.cpu_limit)
         return cpu_available and instance_available

--- a/cloudweatherreport/cloudresource/gce.py
+++ b/cloudweatherreport/cloudresource/gce.py
@@ -6,12 +6,18 @@ from libcloud.common.google import ResourceNotFoundError
 
 from cloudweatherreport.cloudresource import CloudResource
 
+INSTANCE_LIMIT = 200
+SECURITY_GROUP_LIMIT = 100
+CPU_LIMIT = 24
+
 
 class GCE(CloudResource):
     """Determines if the requested resources are available for GCE cloud."""
 
     def __init__(self, sa_email, key, region, project_id,
-                 instance_limit=200, security_group_limit=100, cpu_limit=24):
+                 instance_limit=INSTANCE_LIMIT,
+                 security_group_limit=SECURITY_GROUP_LIMIT,
+                 cpu_limit=CPU_LIMIT):
         super(GCE, self).__init__(
             instance_limit, security_group_limit, cpu_limit)
         self.region = region
@@ -32,12 +38,12 @@ class GCE(CloudResource):
         nodes = filter(lambda n: n.state != 'terminated', nodes)
         instance_count = len(nodes)
 
-        logging.info('GCE instance request')
+        logging.info('GCE instance request. Region:{}'.format(self.region))
         instance_available = self.is_resource_available(
             number_of_instances, instance_count, self.instance_limit)
         cpu_count = sum([self.get_cpu_size_from_node(n) for n in nodes])
 
-        logging.info('GCE CPU resource request')
+        logging.info('GCE CPU resource request. Region:{}'.format(self.region))
         cpu_available = self.is_resource_available(
             number_of_cpus, cpu_count, self.cpu_limit)
         return cpu_available and instance_available
@@ -80,7 +86,8 @@ class GCE(CloudResource):
         :return: boolean
         """
         security_group_count = len(self.client.ex_list_firewalls())
-        logging.info("GCE security groups resource request")
+        logging.info("GCE security groups resource request. Region:{}".format(
+            self.region))
         return self.is_resource_available(
             request, security_group_count, self.security_group_limit)
 

--- a/cloudweatherreport/cloudresource/resource.py
+++ b/cloudweatherreport/cloudresource/resource.py
@@ -1,0 +1,153 @@
+import logging
+import os
+import yaml
+
+import cloudweatherreport.cloudresource.aws as aws
+import cloudweatherreport.cloudresource.gce as gce
+import cloudweatherreport.cloudresource.azure as azure
+from cloudweatherreport.utils import juju_cmd
+
+
+class UnknownCloudName(Exception):
+    pass
+
+
+class UnknownCredentialName(Exception):
+    pass
+
+
+class CloudNotSupported(Exception):
+    pass
+
+
+def get_credential_name(creds, cloud_name):
+    cred_name = creds.get('credentials', {}).get(cloud_name, {}).get(
+        'default-credential')
+    if cred_name:
+        return cred_name
+    # If no default credential name, get the first name from the list
+    names = list(creds.get('credentials', {}).get(cloud_name, {}).keys())
+    return sorted(names)[0]
+
+
+def get_credentials(cloud, name=None):
+    """Get cloud credentials from the juju credentials command."""
+    cmd = 'list-credentials {} --format yaml --show-secrets'.format(cloud)
+    creds = juju_cmd(cmd)
+    creds = yaml.safe_load(creds)
+    if not creds or not creds.get('credentials', {}).get(cloud):
+        raise UnknownCloudName('Cloud not found: {}'.format(cloud))
+
+    name = get_credential_name(creds, cloud) if not name else name
+    try:
+        credentials = creds['credentials'][cloud][name]
+    except KeyError:
+        raise UnknownCredentialName(
+            'Credential name not found cloud:{} name:{}'.format(cloud, name))
+    return credentials
+
+
+def _aws_client(creds, region, instance_limit, security_group_limit):
+    instance_limit = instance_limit or aws.INSTANCE_LIMIT
+    security_group_limit = security_group_limit or aws.SECURITY_GROUP_LIMIT
+    client = aws.AWS(
+        access_key=creds['access-key'],
+        secret_key=creds['secret-key'],
+        region=region,
+        instance_limit=instance_limit,
+        security_group_limit=security_group_limit)
+    return client
+
+
+def _gce_client(creds, region, instance_limit, security_group_limit,
+                cpu_limit):
+    instance_limit = instance_limit or gce.INSTANCE_LIMIT
+    security_group_limit = security_group_limit or gce.SECURITY_GROUP_LIMIT
+    cpu_limit = cpu_limit or gce.CPU_LIMIT
+    client = gce.GCE(
+        sa_email=creds['client-email'],
+        key=creds['private-key'],
+        region=region,
+        project_id=creds['project-id'],
+        instance_limit=instance_limit,
+        security_group_limit=security_group_limit,
+        cpu_limit=cpu_limit
+    )
+    return client
+
+
+def _azure_client(creds, region, instance_limit, security_group_limit,
+                  cpu_limit, azure_tenant_id):
+    instance_limit = instance_limit or azure.INSTANCE_LIMIT
+    security_group_limit = security_group_limit or azure.SECURITY_GROUP_LIMIT
+    cpu_limit = cpu_limit or azure.CORE_LIMIT
+    client = azure.Azure(
+        tenant_id=azure_tenant_id,
+        subscription_id=creds['subscription-id'],
+        application_id=creds['application-id'],
+        application_password=creds['application-password'],
+        region=region,
+        instance_limit=instance_limit,
+        security_group_limit=security_group_limit,
+        core_limit=cpu_limit
+    )
+    return client
+
+
+def is_resource_available(cloud, region,
+                          num_of_instances,
+                          num_of_security_groups,
+                          num_of_cpus,
+                          instance_limit=None,
+                          security_group_limit=None,
+                          cpu_limit=None,
+                          credentials_name=None,
+                          azure_tenant_id=None):
+    """Determine if resources are available to perform tests.
+
+    Check if instance/machine, security group and CPU resources
+    are available before performing cwr tests.
+
+    :param cloud: Cloud name
+    :param region: Cloud region
+    :param num_of_instances: Number of instances needed to perform tests.
+    :param num_of_security_groups: Number of security groups needed.
+    :param num_of_cpus: Number of CPUs needed
+    :param instance_limit:  Instance or machine limit
+    :param security_group_limit: Security group limit
+    :param cpu_limit:  CPU or core limit. Ignored for AWS cloud.
+    :param credentials_name:  Juju credentials name.
+    :param azure_tenant_id: Azure tenant id if cloud is set to azure. If set to
+      None, it tries to use the AZURE_TENANT_ID environment variable.
+    :return boolean
+    """
+    logging.info('Checking resource for {}'.format(cloud))
+    azure_tenant_id = azure_tenant_id or os.getenv('AZURE_TENANT_ID')
+    creds = get_credentials(cloud, credentials_name)
+
+    if 'aws' in cloud.lower():
+        client = _aws_client(
+            creds, region, instance_limit, security_group_limit)
+        security_available = client.is_security_group_available(
+            num_of_security_groups)
+    elif 'google' in cloud.lower():
+        client = _gce_client(
+            creds, region, instance_limit, security_group_limit, cpu_limit)
+        security_available = client.is_security_group_available(
+            num_of_security_groups)
+    elif 'azure' in cloud.lower():
+        if azure_tenant_id is None:
+            raise CloudNotSupported(
+                'Tenant ID is required to check for Azure resources')
+        client = _azure_client(
+            creds, region, instance_limit, security_group_limit, cpu_limit,
+            azure_tenant_id)
+        # Azure does not support listing security groups
+        security_available = True
+    else:
+        raise CloudNotSupported('Cloud not supported {}'.format(cloud))
+
+    instance_available = client.is_instance_available(
+        num_of_instances, num_of_cpus)
+
+    return instance_available is True and security_available is True

--- a/cloudweatherreport/cloudresource/resource.py
+++ b/cloudweatherreport/cloudresource/resource.py
@@ -25,9 +25,17 @@ def get_credential_name(creds, cloud_name):
         'default-credential')
     if cred_name:
         return cred_name
-    # If no default credential name, get the first name from the list
+
     names = list(creds.get('credentials', {}).get(cloud_name, {}).keys())
-    return sorted(names)[0]
+    try:
+        names.remove('default-region')
+    except ValueError:
+        pass
+    if len(names) > 1:
+        raise ValueError(
+            'More than one credential is available. Set default juju '
+            'credential or set JUJU_CREDENTIAL_NAME system variable.')
+    return names[0]
 
 
 def get_credentials(cloud, name=None):

--- a/cloudweatherreport/model.py
+++ b/cloudweatherreport/model.py
@@ -285,6 +285,7 @@ class TestPlan(BaseModel):
         'tests': list([basestring]),
         'url': basestring,
         'test_label': basestring,
+        'cloud_resource': dict,
     }
 
     @classmethod

--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -201,12 +201,13 @@ class Runner(mp.Process):
                 instance_limit=machine_limit,
                 security_group_limit=sec_limit,
                 cpu_limit=cpu_limit,
-                credentials_name=os.getenv('{}')
+                credentials_name=os.getenv('JUJU_CREDENTIAL_NAME')
             )
-        except (CloudNotSupported, UnknownCloudName,
-                UnknownCredentialName) as e:
+        except (UnknownCloudName, UnknownCredentialName) as e:
             logging.error(
                 'Skipping cloud resource check: {}'.format(str(e)))
+        except CloudNotSupported as e:
+            logging.info('Skipping cloud resource check: {}'.format(str(e)))
             return None
 
     def run_plan(self, test_plan):

--- a/cloudweatherreport/utils.py
+++ b/cloudweatherreport/utils.py
@@ -163,7 +163,8 @@ def create_bundle_yaml(name=None):
 
 def configure_logging(log_level=logging.WARNING):
     logging.basicConfig(
-        level=log_level, format='%(asctime)s %(levelname)s %(message)s',
+        level=log_level,
+        format='%(filename)s:%(asctime)s %(levelname)s %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S')
 
 
@@ -301,3 +302,9 @@ def write_to_datastore(datastore, index, update_summary=False):
     datastore.write(index.full_index_filename_html, index.as_html())
     datastore.write(index.summary_filename_json, index.summary_json())
     datastore.write(index.summary_filename_html, index.summary_html())
+
+
+def juju_cmd(cmd):
+    cmd = cmd.split() if isinstance(cmd, str) else cmd
+    cmd = ['juju'] + cmd
+    return subprocess.check_output(cmd)

--- a/cloudweatherreport/utils.py
+++ b/cloudweatherreport/utils.py
@@ -307,4 +307,4 @@ def write_to_datastore(datastore, index, update_summary=False):
 def juju_cmd(cmd):
     cmd = cmd.split() if isinstance(cmd, str) else cmd
     cmd = ['juju'] + cmd
-    return subprocess.check_output(cmd)
+    return subprocess.check_output(cmd).decode('utf-8')

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,0 +1,193 @@
+from textwrap import dedent
+from unittest import TestCase
+import os
+
+from mock import patch
+from yaml import safe_load
+
+from cloudweatherreport.cloudresource.resource import (
+    get_credentials,
+    is_resource_available,
+    CloudNotSupported,
+    UnknownCloudName,
+    UnknownCredentialName,
+)
+
+
+class TestGetCredentials(TestCase):
+
+    fake_creds = dedent("""\
+    credentials:
+        aws:
+            default-credential: cred
+            cred:
+                auth-type: access-key
+                access-key: aws-access-key
+                secret-key: aws-secret-key
+            cred2:
+                auth-type: access-key2
+                access-key: aws-access-key2
+                secret-key: aws-secret-key2
+        google:
+            default-credentials: cred
+            cred:
+                auth-type: oauth
+                client-email: thedude@example.com
+                client-id: 1234
+                project-id: p-id
+                private-key: |
+                  asdf1234
+                """)
+    fake_creds_no_default = dedent("""\
+    credentials:
+        aws:
+            cred4:
+                auth-type: access-key4
+                access-key: aws-access-key4
+                secret-key: aws-secret-key4
+            cred3:
+                auth-type: access-key3
+                access-key: aws-access-key3
+                secret-key: aws-secret-key3
+        azure:
+            cred6:
+              application-id: 1234-abc
+              application-password: pass
+              subscription-id: asdf-1234
+        google:
+            cred5:
+                client-email: thedude@example.com5
+                client-id: 12345
+                project-id: p-id2
+                private-key: |
+                  asdf12345
+                """)
+
+    @patch('subprocess.check_output', autospec=True)
+    def test_get_credentials_default_creds(self, cc_mock):
+        cc_mock.return_value = self.fake_creds
+        creds = get_credentials('aws')
+        expected = safe_load(self.fake_creds)['credentials']['aws']['cred']
+        self.assertEqual(creds, expected)
+
+        creds = get_credentials('google')
+        expected = safe_load(self.fake_creds)['credentials']['google']['cred']
+        self.assertEqual(creds, expected)
+
+    @patch('subprocess.check_output', autospec=True)
+    def test_get_credentials_default_creds_named_cred(self, cc_mock):
+        cc_mock.return_value = self.fake_creds
+        creds = get_credentials('aws', 'cred')
+        expected = safe_load(self.fake_creds)['credentials']['aws']['cred']
+        self.assertEqual(creds, expected)
+
+        creds = get_credentials('google', 'cred')
+        expected = safe_load(self.fake_creds)['credentials']['google']['cred']
+        self.assertEqual(creds, expected)
+
+    @patch('subprocess.check_output', autospec=True)
+    def test_get_credentials_no_default_creds(self, cc_mock):
+        cc_mock.return_value = self.fake_creds_no_default
+        creds = get_credentials('aws')
+        expected = safe_load(self.fake_creds_no_default)
+        expected = expected['credentials']['aws']['cred3']
+        self.assertEqual(creds, expected)
+
+        creds = get_credentials('google')
+        expected = safe_load(self.fake_creds_no_default)
+        expected = expected['credentials']['google']['cred5']
+        self.assertEqual(creds, expected)
+
+    @patch('subprocess.check_output', autospec=True)
+    def test_get_credentials_no_default_creds_named_cred(self, cc_mock):
+        cc_mock.return_value = self.fake_creds_no_default
+        creds = get_credentials('aws', 'cred4')
+        expected = safe_load(self.fake_creds_no_default)
+        expected = expected['credentials']['aws']['cred4']
+        self.assertEqual(creds, expected)
+
+        creds = get_credentials('google', 'cred5')
+        expected = safe_load(self.fake_creds_no_default)
+        expected = expected['credentials']['google']['cred5']
+        self.assertEqual(creds, expected)
+
+    @patch('subprocess.check_output', autospec=True)
+    def test_get_credentials_unknown_cloud_name(self, cc_mock):
+        cc_mock.return_value = 'credentials: {}'
+        with self.assertRaisesRegexp(UnknownCloudName, "Cloud not found:"):
+            get_credentials('foo')
+
+    @patch('subprocess.check_output', autospec=True)
+    def test_get_credentials_unknown_cred_name(self, cc_mock):
+        cc_mock.return_value = self.fake_creds_no_default
+        with self.assertRaisesRegexp(
+                UnknownCredentialName, "Credential name not found"):
+            get_credentials('google', 'foo')
+
+
+class TestIsResourceAvailable(TestCase):
+
+    @patch('subprocess.check_output', autospec=True)
+    @patch('cloudweatherreport.cloudresource.aws.AWS', autospec=True)
+    def test_is_resource_available_aws(self, aws_mock, cc_mock):
+        aws_mock.return_value.is_security_group_available.return_value = True
+        aws_mock.return_value.is_instance_available.return_value = True
+        cc_mock.return_value = TestGetCredentials.fake_creds_no_default
+        result = is_resource_available('aws', 'us-west-1', 1, 1, 1)
+        self.assertIs(result, True)
+        cc_mock.assert_called_once_with(
+            ['juju', 'list-credentials', 'aws', '--format', 'yaml',
+             '--show-secrets'])
+        aws_mock.assert_called_once_with(
+            access_key='aws-access-key3', instance_limit=20,
+            region='us-west-1', secret_key='aws-secret-key3',
+            security_group_limit=500)
+
+    @patch('subprocess.check_output', autospec=True)
+    @patch('cloudweatherreport.cloudresource.gce.GCE', autospec=True)
+    def test_is_resource_availablegce(self, gce_mock, cc_mock):
+        gce_mock.return_value.is_security_group_available.return_value = True
+        gce_mock.return_value.is_instance_available.return_value = True
+        cc_mock.return_value = TestGetCredentials.fake_creds_no_default
+        result = is_resource_available('google', 'us-west1', 1, 1, 1)
+        self.assertIs(result, True)
+        cc_mock.assert_called_once_with(
+            ['juju', 'list-credentials', 'google', '--format', 'yaml',
+             '--show-secrets'])
+        gce_mock.assert_called_once_with(
+            cpu_limit=24, instance_limit=200, key='asdf12345\n',
+            project_id='p-id2', region='us-west1',
+            sa_email='thedude@example.com5', security_group_limit=100)
+
+    @patch('subprocess.check_output', autospec=True)
+    @patch('cloudweatherreport.cloudresource.azure.Azure', autospec=True)
+    def test_is_resource_available_azure(self, azure_mock, cc_mock):
+        azure_mock.return_value.is_instance_available.return_value = True
+        cc_mock.return_value = TestGetCredentials.fake_creds_no_default
+        os.environ['AZURE_TENANT_ID'] = 'tenant id'
+        result = is_resource_available('azure', 'westus', 1, 1, 1)
+        del os.environ['AZURE_TENANT_ID']
+        self.assertIs(result, True)
+        cc_mock.assert_called_once_with(
+            ['juju', 'list-credentials', 'azure', '--format', 'yaml',
+             '--show-secrets'])
+        azure_mock.assert_called_once_with(
+            application_id='1234-abc', application_password='pass',
+            core_limit=20, instance_limit=60, region='westus',
+            security_group_limit=100, subscription_id='asdf-1234',
+            tenant_id='tenant id')
+
+    @patch('subprocess.check_output', autospec=True)
+    @patch('cloudweatherreport.cloudresource.azure.Azure', autospec=True)
+    def test_is_resource_available_raises_exception(self, azure_mock, cc_mock):
+        cc_mock.return_value = 'credentials: {}'
+        with self.assertRaisesRegexp(UnknownCloudName, 'Cloud not found'):
+            is_resource_available('azure', 'westus', 1, 1, 1)
+        cc_mock.assert_called_once_with(
+            ['juju', 'list-credentials', 'azure', '--format', 'yaml',
+             '--show-secrets'])
+
+        cc_mock.return_value = TestGetCredentials.fake_creds_no_default
+        with self.assertRaisesRegexp(
+                CloudNotSupported, 'Tenant ID is required'):
+            is_resource_available('azure', 'westus', 1, 1, 1)


### PR DESCRIPTION
Added code to check for resource availability before performing cwr tests. When you add the following fields in the test plan, it automatically checks if the number of machines and CPUs are available from the provider before running the test:

```
cloud_resource:
    machines: 5
    cpus: 10

```
It checks resource availability by calculating how many resources you are already using and how many more you are requesting from the provider. In case of not having enough resources, it generates `resource not available` test result. See attached image.

I tested the code on running AWS, GCE, Azure and LXD. 

I will update the doc once this is landed.

![resource-not-available](https://cloud.githubusercontent.com/assets/1581316/24686370/5294fc48-1968-11e7-88a0-655b03dceef9.png)
