### PR TITLE
Generate test report for failed tests.

### DIFF
--- a/cloudweatherreport/model.py
+++ b/cloudweatherreport/model.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import re
 import json
 import yaml
@@ -22,6 +23,11 @@ except NameError:
 
 
 log = logging.getLogger(__name__)
+
+
+TestOutcomes = namedtuple('TestOutcome', 'passed fail infra none')
+TEST_OUTCOMES = TestOutcomes(
+    passed='PASS', fail='FAIL', infra='INFRA', none='NONE')
 
 
 # ******** Base types


### PR DESCRIPTION
 - Generate test report for when it failed to connect to `juju client` and when exception is raised
-  Removed unused `generate_test_result`
Fixes #104 