### PR TITLE
add bt --no-matrix arg; require bt >= 0.12.0

### DIFF
--- a/cloudweatherreport/run.py
+++ b/cloudweatherreport/run.py
@@ -95,6 +95,9 @@ def parse_args(argv=None):
                         help='A plan to deploy charm under')
     parser.add_argument('--deploy-budget',
                         help='Deploy budget and allocation limit')
+    parser.add_argument('--no-matrix', action="store_true",
+                        help="Skip matrix test run, even if juju-matrix is "
+                        "in your path.")
     options = parser.parse_args(argv)
     options.juju_major_version = get_juju_major_version()
     configure_logging(getattr(logging, options.log_level))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apache-libcloud
 PyYAML==3.11
-bundletester
+bundletester>=0.12.0
 jujuclient>=0.53.0,<1.0.0
 Jinja2
 MarkupSafe

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -189,7 +189,8 @@ class TestRunner(unittest.TestCase):
     def test_run_tests_with_args(self, bt_out, tester_main):
         args = run.parse_args(
             ['aws', 'test_plan', '--test-id', '1234', '--deploy-plan', 'foo',
-             '--deploy-budget', 'bar', '--testdir', '/tmp/testdir'])
+             '--deploy-budget', 'bar', '--testdir', '/tmp/testdir',
+             '--no-matrix'])
         runner = run.Runner('aws', False, args)
         env = mock.Mock(spec_set=['name', 'provider_name'])
         env.name = 'env-name'
@@ -219,6 +220,7 @@ class TestRunner(unittest.TestCase):
             juju_major_version=2,
             log_level='INFO',
             no_destroy=False,
+            no_matrix=True,
             output=str_io,
             regenerate_index=False,
             remove_test=None,
@@ -356,6 +358,7 @@ class TestRunner(unittest.TestCase):
             juju_major_version=2,
             log_level='INFO',
             no_destroy=False,
+            no_matrix=False,
             regenerate_index=False,
             remove_test=None,
             results_dir='results',


### PR DESCRIPTION
Since cwr invokes Bundletester.tester directly, it doesn't play nicely with new bt args.  This would lead to failures like this:

```
$ env MATRIX_MODEL_PREFIX=job-45-matrix MATRIX_OUTPUT_DIR=/srv/artifacts/cwr_charm_release_ubuntu_devenv_in_cs__kwmonroe_java_devenv/45 cwr -F -l DEBUG -v aws-w:ci-70/job-45-boss-crow totest.yaml --results-dir /srv/artifacts --test-id 45
2017-05-10 19:31:11 DEBUG Connecting to wss://54.193.126.125:17070/model/70587bb5-5b30-4517-8045-469572be6810/api
2017-05-10 19:31:12 INFO Running test on AWS.
2017-05-10 19:31:12 DEBUG Cache dir /root/.local/share/juju/.deployer-store-cache/cs_xenial_openjdk-5
2017-05-10 19:31:12 DEBUG Retrieving store charm cs:xenial/openjdk-5
2017-05-10 19:31:13 ERROR Exception (aws-w:ci-70/job-45-boss-crow):
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/cloudweatherreport/run.py", line 161, in run_plan
    test_result = self.run_tests(test_plan, env)
  File "/usr/local/lib/python2.7/dist-packages/cloudweatherreport/run.py", line 232, in run_tests
    status = tester.main(self.args)
  File "/usr/local/lib/python2.7/dist-packages/bundletester/tester.py", line 140, in main
    suite = spec.SuiteFactory(options, options.testdir)
  File "/usr/local/lib/python2.7/dist-packages/bundletester/spec.py", line 393, in SuiteFactory
    suite.find_suite()
  File "/usr/local/lib/python2.7/dist-packages/bundletester/spec.py", line 247, in find_suite
    self.conditional_matrix(self.model['directory'])
  File "/usr/local/lib/python2.7/dist-packages/bundletester/spec.py", line 271, in conditional_matrix
    if self.options.no_matrix:
AttributeError: 'Namespace' object has no attribute 'no_matrix'
```

Perhaps we should rework how cwr integrates with bt, but for now, keeping the cwr arg list in sync with bt will keep up limping along.

Untested for now, but what could possibly go wrong?!?!